### PR TITLE
feature/GRA-003: Implementing Use Cases and Ports for Movie, Producer, and Studio Insertion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -42,6 +46,23 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<version>6.4.4.Final</version>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>com.opencsv</groupId>
+			<artifactId>opencsv</artifactId>
+			<version>5.9</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -49,6 +70,21 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>{$java.version}</source>
+					<target>{$java.version}</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.5.5.Final</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/InsertMovieUseCase.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/InsertMovieUseCase.java
@@ -1,0 +1,20 @@
+package com.texoit.goldenraspberryawardsapi.application.core.usecase;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertMovieInputPort;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.InsertMovieOutputPort;
+
+public class InsertMovieUseCase implements InsertMovieInputPort {
+
+    private final InsertMovieOutputPort insertMovieOutputPort;
+
+    public InsertMovieUseCase(InsertMovieOutputPort insertMovieOutputPort) {
+        this.insertMovieOutputPort = insertMovieOutputPort;
+    }
+
+    @Override
+    public Movie insert(Movie movie){
+        return insertMovieOutputPort.insert(movie);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/InsertProducerUseCase.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/InsertProducerUseCase.java
@@ -1,0 +1,20 @@
+package com.texoit.goldenraspberryawardsapi.application.core.usecase;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertProducerInputPort;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.InsertProducerOutputPort;
+
+public class InsertProducerUseCase implements InsertProducerInputPort {
+
+    private final InsertProducerOutputPort insertProducerOutputPort;
+
+    public InsertProducerUseCase(InsertProducerOutputPort insertProducerOutputPort) {
+        this.insertProducerOutputPort = insertProducerOutputPort;
+    }
+
+    @Override
+    public Producer insert(Producer Producer){
+        return insertProducerOutputPort.insert(Producer);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/InsertStudioUseCase.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/InsertStudioUseCase.java
@@ -1,6 +1,5 @@
 package com.texoit.goldenraspberryawardsapi.application.core.usecase;
 
-import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
 import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
 import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertStudioInputPort;
 import com.texoit.goldenraspberryawardsapi.application.ports.out.InsertStudioOutputPort;

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/InsertStudioUseCase.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/InsertStudioUseCase.java
@@ -1,0 +1,21 @@
+package com.texoit.goldenraspberryawardsapi.application.core.usecase;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertStudioInputPort;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.InsertStudioOutputPort;
+
+public class InsertStudioUseCase implements InsertStudioInputPort {
+
+    private final InsertStudioOutputPort insertStudioOutputPort;
+
+    public InsertStudioUseCase(InsertStudioOutputPort insertStudioOutputPort) {
+        this.insertStudioOutputPort = insertStudioOutputPort;
+    }
+
+    @Override
+    public Studio insert(Studio Studio){
+        return insertStudioOutputPort.insert(Studio);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/InsertMovieInputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/InsertMovieInputPort.java
@@ -1,0 +1,9 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.in;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+
+public interface InsertMovieInputPort {
+
+    Movie insert(Movie movie);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/InsertProducerInputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/InsertProducerInputPort.java
@@ -1,0 +1,9 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.in;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+
+public interface InsertProducerInputPort {
+
+    Producer insert(Producer producer);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/InsertStudioInputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/InsertStudioInputPort.java
@@ -1,6 +1,5 @@
 package com.texoit.goldenraspberryawardsapi.application.ports.in;
 
-import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
 import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
 
 public interface InsertStudioInputPort {

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/InsertStudioInputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/InsertStudioInputPort.java
@@ -1,0 +1,10 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.in;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+
+public interface InsertStudioInputPort {
+
+    Studio insert(Studio studio);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/InsertMovieOutputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/InsertMovieOutputPort.java
@@ -1,0 +1,9 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.out;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+
+public interface InsertMovieOutputPort {
+
+    Movie insert(Movie movie);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/InsertProducerOutputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/InsertProducerOutputPort.java
@@ -1,0 +1,9 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.out;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+
+public interface InsertProducerOutputPort {
+
+    Producer insert(Producer producer);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/InsertStudioOutputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/InsertStudioOutputPort.java
@@ -1,0 +1,10 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.out;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+
+public interface InsertStudioOutputPort {
+
+    Studio insert(Studio studio);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/InsertStudioOutputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/InsertStudioOutputPort.java
@@ -1,6 +1,5 @@
 package com.texoit.goldenraspberryawardsapi.application.ports.out;
 
-import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
 import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
 
 public interface InsertStudioOutputPort {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
-
+# H2 Settings
+spring.datasource.url=jdbc:h2:mem:goldenraspberryawards
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.properties.hibernate.globally_quoted_identifiers=true
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console


### PR DESCRIPTION
### Changes Made
- Added use cases and corresponding input/output ports for inserting Movie, Producer, and Studio entities.
- Introduced InsertMovieUseCase, InsertProducerUseCase, and InsertStudioUseCase within the application layer.
- Each use case utilizes an associated input port (InsertMovieInputPort, InsertProducerInputPort, InsertStudioInputPort) and output port (InsertMovieOutputPort, InsertProducerOutputPort, InsertStudioOutputPort) for decoupling dependencies.

### Context
This pull request addresses GRA-003, focusing on the implementation of use cases and ports within the application layer. Three distinct use cases (InsertMovieUseCase, InsertProducerUseCase, InsertStudioUseCase) have been introduced to handle the insertion of Movie, Producer, and Studio entities, respectively.

The use cases adhere to the principles of hexagonal architecture, promoting separation of concerns and maintainability. Input and output ports are employed to ensure flexibility and ease of integration with external systems, providing a clear boundary between the application core and external dependencies.