### PR TITLE
feature/GRA-004: Implementing Adapters, JPA Entities, MapStruct Mappers, Spring Data JPA Repositories, and Spring Bean Registration for Insert Operations

### DIFF
--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertMovieAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertMovieAdapter.java
@@ -1,0 +1,28 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.MovieRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.MovieEntity;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.MovieEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.InsertMovieOutputPort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InsertMovieAdapter implements InsertMovieOutputPort {
+
+    private final MovieRepository movieRepository;
+
+    private final MovieEntityMapper movieEntityMapper;
+
+    public InsertMovieAdapter(MovieRepository movieRepository, MovieEntityMapper movieEntityMapper) {
+        this.movieRepository = movieRepository;
+        this.movieEntityMapper = movieEntityMapper;
+    }
+
+    @Override
+    public Movie insert(Movie movie) {
+        MovieEntity movieEntity = movieRepository.save(movieEntityMapper.toMovieEntity(movie));
+        return movieEntityMapper.toMovie(movieEntity);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertProducerAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertProducerAdapter.java
@@ -1,0 +1,28 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.ProducerRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.ProducerEntity;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.ProducerEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.InsertProducerOutputPort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InsertProducerAdapter implements InsertProducerOutputPort {
+
+    private final ProducerRepository producerRepository;
+
+    private final ProducerEntityMapper producerEntityMapper;
+
+    public InsertProducerAdapter(ProducerRepository producerRepository, ProducerEntityMapper producerEntityMapper) {
+        this.producerRepository = producerRepository;
+        this.producerEntityMapper = producerEntityMapper;
+    }
+
+    @Override
+    public Producer insert(Producer producer) {
+        ProducerEntity producerEntity = producerRepository.save(producerEntityMapper.toProducerEntity(producer));
+        return producerEntityMapper.toProducer(producerEntity);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertStudioAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertStudioAdapter.java
@@ -1,0 +1,28 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.StudioRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.StudioEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.InsertStudioOutputPort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InsertStudioAdapter implements InsertStudioOutputPort {
+
+    private final StudioRepository studioRepository;
+
+    private final StudioEntityMapper studioEntityMapper;
+
+    public InsertStudioAdapter(StudioRepository studioRepository, StudioEntityMapper studioEntityMapper) {
+        this.studioRepository = studioRepository;
+        this.studioEntityMapper = studioEntityMapper;
+    }
+
+    @Override
+    public Studio insert(Studio studio) {
+        StudioEntity studioEntity = studioRepository.save(studioEntityMapper.toStudioEntity(studio));
+        return studioEntityMapper.toStudio(studioEntity);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/MovieRepository.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/MovieRepository.java
@@ -1,0 +1,9 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.MovieEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MovieRepository extends JpaRepository<MovieEntity, UUID> {
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/ProducerRepository.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/ProducerRepository.java
@@ -1,0 +1,9 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.ProducerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ProducerRepository extends JpaRepository<ProducerEntity, UUID> {
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/StudioRepository.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/StudioRepository.java
@@ -1,0 +1,9 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface StudioRepository extends JpaRepository<StudioEntity, UUID> {
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/entity/MovieEntity.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/entity/MovieEntity.java
@@ -1,0 +1,98 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity(name = "movie")
+@Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "year", "title" }) })
+public class MovieEntity {
+
+    @Id
+    @UuidGenerator
+    private UUID id;
+    private Integer year;
+    private String title;
+
+    @ManyToMany
+    @JoinTable(
+            name = "movie_producer",
+            joinColumns = @JoinColumn(name = "movie_id"),
+            inverseJoinColumns = @JoinColumn(name = "producer_id")
+    )
+    private Set<ProducerEntity> producers;
+
+    @ManyToMany
+    @JoinTable(
+            name = "movie_studio",
+            joinColumns = @JoinColumn(name = "movie_id"),
+            inverseJoinColumns = @JoinColumn(name = "studio_id")
+    )
+    private Set<StudioEntity> studios;
+
+    private Boolean winner;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public void setYear(Integer year) {
+        this.year = year;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Set<ProducerEntity> getProducers() {
+        return producers;
+    }
+
+    public void setProducers(Set<ProducerEntity> producers) {
+        this.producers = producers;
+    }
+
+    public Set<StudioEntity> getStudios() {
+        return studios;
+    }
+
+    public void setStudios(Set<StudioEntity> studios) {
+        this.studios = studios;
+    }
+
+    public Boolean getWinner() {
+        return winner;
+    }
+
+    public void setWinner(Boolean winner) {
+        this.winner = winner;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MovieEntity that = (MovieEntity) o;
+        return Objects.equals(id, that.id) && Objects.equals(year, that.year) && Objects.equals(title, that.title) && Objects.equals(producers, that.producers) && Objects.equals(studios, that.studios) && Objects.equals(winner, that.winner);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, year, title, producers, studios, winner);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/entity/ProducerEntity.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/entity/ProducerEntity.java
@@ -1,0 +1,61 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.*;
+
+@Entity(name = "producer")
+public class ProducerEntity {
+
+    @Id
+    @UuidGenerator
+    private UUID id;
+    @Column(unique = true)
+    private String name;
+
+    @ManyToMany(mappedBy = "producers")
+    private final Set<MovieEntity> movies;
+
+    public ProducerEntity() {
+        this.movies = new LinkedHashSet<>();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setMovies(Set<MovieEntity> movies) {
+        this.movies.clear();
+        this.movies.addAll(movies);
+    }
+
+    public Set<MovieEntity> getMovies() {
+        return Collections.unmodifiableSet(movies);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProducerEntity that = (ProducerEntity) o;
+        return Objects.equals(id, that.id) && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/entity/StudioEntity.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/entity/StudioEntity.java
@@ -1,0 +1,51 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity(name = "studio")
+public class StudioEntity {
+
+    @Id
+    @UuidGenerator
+    private UUID id;
+    @Column(unique = true)
+    private String name;
+
+    public StudioEntity() {
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StudioEntity that = (StudioEntity) o;
+        return Objects.equals(id, that.id) && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/MovieEntityMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/MovieEntityMapper.java
@@ -1,0 +1,31 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.MovieEntity;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+import java.util.stream.Collectors;
+
+@Mapper(componentModel = "spring", uses = {StudioEntityMapper.class, ProducerEntityMapper.class})
+public interface MovieEntityMapper {
+
+    @Mapping(target = "producers", ignore = true)
+    MovieEntity toMovieEntity(Movie movie);
+
+    ProducerEntityMapper producerEntityMapper = Mappers.getMapper(ProducerEntityMapper.class);
+
+    @AfterMapping
+    default void mapProducers(Movie movie, @MappingTarget MovieEntity movieEntity) {
+        movieEntity.setProducers(
+                movie.getProducers().stream()
+                        .map(producerEntityMapper::toProducerEntity)
+                        .collect(Collectors.toSet())
+        );
+    }
+
+    Movie toMovie(MovieEntity movieEntity);
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/ProducerEntityMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/ProducerEntityMapper.java
@@ -1,0 +1,14 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.MovieEntity;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.ProducerEntity;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ProducerEntityMapper {
+
+    ProducerEntity toProducerEntity(Producer producer);
+    Producer toProducer(ProducerEntity producerEntity);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/StudioEntityMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/StudioEntityMapper.java
@@ -1,0 +1,13 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface StudioEntityMapper {
+
+    StudioEntity toStudioEntity(Studio studio);
+    Studio toStudio(StudioEntity studioEntity);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/config/InsertMovieConfig.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/config/InsertMovieConfig.java
@@ -1,0 +1,16 @@
+package com.texoit.goldenraspberryawardsapi.config;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.InsertMovieAdapter;
+import com.texoit.goldenraspberryawardsapi.application.core.usecase.InsertMovieUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class InsertMovieConfig {
+
+    @Bean
+    public InsertMovieUseCase insertMovieUseCase(InsertMovieAdapter insertMovieAdapter) {
+        return new InsertMovieUseCase(insertMovieAdapter);
+    }
+    
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/config/InsertProducerConfig.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/config/InsertProducerConfig.java
@@ -1,0 +1,16 @@
+package com.texoit.goldenraspberryawardsapi.config;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.InsertProducerAdapter;
+import com.texoit.goldenraspberryawardsapi.application.core.usecase.InsertProducerUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class InsertProducerConfig {
+
+    @Bean
+    public InsertProducerUseCase insertProducerUseCase(InsertProducerAdapter insertProducerAdapter) {
+        return new InsertProducerUseCase(insertProducerAdapter);
+    }
+    
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/config/InsertStudioConfig.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/config/InsertStudioConfig.java
@@ -1,0 +1,16 @@
+package com.texoit.goldenraspberryawardsapi.config;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.InsertStudioAdapter;
+import com.texoit.goldenraspberryawardsapi.application.core.usecase.InsertStudioUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class InsertStudioConfig {
+
+    @Bean
+    public InsertStudioUseCase insertStudioUseCase(InsertStudioAdapter insertStudioAdapter) {
+        return new InsertStudioUseCase(insertStudioAdapter);
+    }
+
+}


### PR DESCRIPTION
### Changes Made
- Introduced JPA entities (MovieEntity, ProducerEntity, StudioEntity) representing database models for Movie, Producer, and Studio.
- Implemented MapStruct mappers (MovieEntityMapper, ProducerEntityMapper, StudioEntityMapper) to facilitate conversion between domain and JPA entities.
- Created Spring Data JPA repositories (MovieRepository, ProducerRepository, StudioRepository) for database interactions.
- Developed adapters (InsertMovieAdapter, InsertProducerAdapter, InsertStudioAdapter) implementing output ports for inserting Movie, Producer, and Studio entities into the database.
- Configured Spring Beans (InsertMovieConfig, InsertProducerConfig, InsertStudioConfig) to register use cases with their corresponding adapters.

### Context
This pull request addresses GRA-004, focusing on the implementation of adapters, JPA entities, MapStruct mappers, Spring Data JPA repositories, and Spring Bean registration. The entities and mappers enable seamless communication between the domain and the database, while the repositories facilitate data persistence.

Adapters (InsertMovieAdapter, InsertProducerAdapter, InsertStudioAdapter) act as bridges between the use cases and the database, allowing for the insertion of Movie, Producer, and Studio entities. The Spring Bean configurations (InsertMovieConfig, InsertProducerConfig, InsertStudioConfig) ensure that the use cases are appropriately registered and available for dependency injection.