### PR TITLE
feature/GRA-005: Refactoring Controllers, Mappers, Request/Response Objects, and Repository Adapters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
 			<artifactId>opencsv</artifactId>
 			<version>5.9</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/MovieController.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/MovieController.java
@@ -1,0 +1,47 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller;
+
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.mapper.MovieMapper;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.MovieRequest;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.MovieResponse;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.MovieRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.MovieEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertMovieInputPort;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/v1/movies")
+public class MovieController {
+
+    private final InsertMovieInputPort insertMovieInputPort;
+    private final MovieMapper movieMapper;
+    private final MovieRepository movieRepository;
+    private final MovieEntityMapper movieEntityMapper;
+
+    public MovieController(InsertMovieInputPort insertMovieInputPort, MovieMapper movieMapper, MovieRepository movieRepository, MovieEntityMapper movieEntityMapper) {
+        this.insertMovieInputPort = insertMovieInputPort;
+        this.movieMapper = movieMapper;
+        this.movieRepository = movieRepository;
+        this.movieEntityMapper = movieEntityMapper;
+    }
+
+    @PostMapping
+    public ResponseEntity<MovieResponse> insert(@Valid @RequestBody MovieRequest movieRequest, UriComponentsBuilder uriBuilder) {
+        var movie = insertMovieInputPort.insert(movieMapper.toMovie(movieRequest));
+        var uri = uriBuilder.path("api/v1/movies/{id}").buildAndExpand(movie.getId()).toUri();
+
+        return ResponseEntity.created(uri).body(movieMapper.toMovieResponse(movie));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MovieResponse> retrieve(@PathVariable UUID id) {
+        var movieResponse = movieMapper.toMovieResponse(movieEntityMapper.toMovie(movieRepository.getReferenceById(id)));
+        return ResponseEntity.ok(movieResponse);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/ProducerController.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/ProducerController.java
@@ -1,0 +1,46 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller;
+
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.mapper.ProducerMapper;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.ProducerRequest;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.ProducerResponse;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.ProducerRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.ProducerEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertProducerInputPort;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/v1/producers")
+public class ProducerController {
+
+    private final InsertProducerInputPort insertProducerInputPort;
+    private final ProducerMapper producerMapper;
+    private final ProducerRepository producerRepository;
+    private final ProducerEntityMapper producerEntityMapper;
+
+    public ProducerController(InsertProducerInputPort insertProducerInputPort, ProducerMapper producerMapper, ProducerRepository producerRepository, ProducerEntityMapper producerEntityMapper) {
+        this.insertProducerInputPort = insertProducerInputPort;
+        this.producerMapper = producerMapper;
+        this.producerRepository = producerRepository;
+        this.producerEntityMapper = producerEntityMapper;
+    }
+
+    @PostMapping
+    public ResponseEntity<ProducerResponse> insert(@Valid @RequestBody ProducerRequest producerRequest, UriComponentsBuilder uriBuilder) {
+        var producer = insertProducerInputPort.insert(producerMapper.toProducer(producerRequest));
+        var uri = uriBuilder.path("api/v1/producers/{id}").buildAndExpand(producer.getId()).toUri();
+
+        return ResponseEntity.created(uri).body(producerMapper.toProducerResponse(producer));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProducerResponse> retrieve(@PathVariable UUID id) {
+        var producerResponse = producerMapper.toProducerResponse(producerEntityMapper.toProducer(producerRepository.getReferenceById(id)));
+        return ResponseEntity.ok(producerResponse);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/StudioController.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/StudioController.java
@@ -1,0 +1,45 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller;
+
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.mapper.StudioMapper;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.StudioRequest;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.StudioResponse;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.StudioRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.MovieStudioEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertStudioInputPort;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/v1/studios")
+public class StudioController {
+
+    private final InsertStudioInputPort insertStudioInputPort;
+    private final StudioMapper studioMapper;
+    private final MovieStudioEntityMapper studioEntityMapper;
+    private final StudioRepository studioRepository;
+
+    public StudioController(InsertStudioInputPort insertStudioInputPort, StudioMapper studioMapper, MovieStudioEntityMapper studioEntityMapper, StudioRepository studioRepository) {
+        this.insertStudioInputPort = insertStudioInputPort;
+        this.studioMapper = studioMapper;
+        this.studioEntityMapper = studioEntityMapper;
+        this.studioRepository = studioRepository;
+    }
+
+    @PostMapping
+    public ResponseEntity<StudioResponse> insert(@Valid @RequestBody StudioRequest studioRequest, UriComponentsBuilder uriBuilder) {
+        var studio = insertStudioInputPort.insert(studioMapper.toStudio(studioRequest));
+        var uri = uriBuilder.path("api/v1/studios/{id}").buildAndExpand(studio.getId()).toUri();
+
+        return ResponseEntity.created(uri).body(studioMapper.toStudioResponse(studio));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<StudioResponse> retrieve(@PathVariable UUID id) {
+        var studioResponse = studioMapper.toStudioResponse(studioEntityMapper.toStudio(studioRepository.getReferenceById(id)));
+        return ResponseEntity.ok(studioResponse);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/mapper/MovieMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/mapper/MovieMapper.java
@@ -1,0 +1,28 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.mapper;
+
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.MovieRequest;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.ProducerRequest;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.MovieResponse;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.ProducerResponse;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.MovieEntity;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.MovieProducerEntityMapper;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.ProducerEntityMapper;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.StudioEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+import java.util.stream.Collectors;
+
+@Mapper(componentModel = "spring", uses = {StudioMapper.class, MovieProducerEntityMapper.class})
+public interface MovieMapper {
+
+    Movie toMovie(MovieRequest movieRequest);
+
+    MovieResponse toMovieResponse(Movie movie);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/mapper/MovieProducerMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/mapper/MovieProducerMapper.java
@@ -1,0 +1,18 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.mapper;
+
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.ProducerRequest;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.ProducerResponse;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.MovieProducerEntityMapper;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.StudioEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface MovieProducerMapper {
+
+    Producer toProducer(ProducerRequest producerRequest);
+    @Mapping(target = "movies", ignore = true)
+    ProducerResponse toProducerResponse(Producer producer);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/mapper/ProducerMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/mapper/ProducerMapper.java
@@ -1,0 +1,17 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.mapper;
+
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.ProducerRequest;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.StudioRequest;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.ProducerResponse;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.StudioResponse;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ProducerMapper {
+
+    Producer toProducer(ProducerRequest producerRequest);
+    ProducerResponse toProducerResponse(Producer producer);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/mapper/StudioMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/mapper/StudioMapper.java
@@ -1,0 +1,15 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.mapper;
+
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.StudioRequest;
+import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.StudioResponse;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface StudioMapper {
+
+    Studio toStudio(StudioRequest studioRequest);
+    StudioResponse toStudioResponse(Studio studio);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/request/MovieProducerRequest.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/request/MovieProducerRequest.java
@@ -1,0 +1,13 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record MovieProducerRequest(
+        @NotNull(message = "O produtor precisa ser informado")
+        UUID id
+) {
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/request/MovieRequest.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/request/MovieRequest.java
@@ -1,0 +1,37 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.request;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record MovieRequest(
+        @NotNull(message = "O ano deve ser informado")
+        Integer year,
+        @NotBlank(message = "O título não deve estar em branco")
+        String title,
+        @NotEmpty(message = "Deve haver pelo menos um estúdio relacionado ao filme")
+        Set<MovieStudioRequest> studios,
+        @NotEmpty(message = "Deve haver pelo menos um produtor relacionado ao filme")
+        Set<MovieProducerRequest> producers,
+        Boolean winner
+) {
+    public MovieRequest {
+        if(winner == null) winner = false;
+    }
+}
+
+
+/*
+    Integer year;
+    String title;
+    final Set<Studio> studios;
+    final Set<Producer> producers;
+    Boolean winner;
+
+        @NotBlank(message = "O nome não deve estar em branco")
+    */

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/request/MovieStudioRequest.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/request/MovieStudioRequest.java
@@ -1,0 +1,12 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record MovieStudioRequest(
+        @NotNull(message = "O estúdio precisa ser informado")
+        UUID id
+) {
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/request/ProducerRequest.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/request/ProducerRequest.java
@@ -1,0 +1,10 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ProducerRequest(
+        @NotBlank(message = "O nome não deve estar em branco")
+        String name
+) {
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/request/StudioRequest.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/request/StudioRequest.java
@@ -1,0 +1,10 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record StudioRequest(
+    @NotBlank(message = "O nome não deve estar em branco")
+    String name
+) {
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/response/MovieProducerResponse.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/response/MovieProducerResponse.java
@@ -1,0 +1,11 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.response;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record MovieProducerResponse(
+        UUID id,
+        String name
+) {
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/response/MovieResponse.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/response/MovieResponse.java
@@ -1,0 +1,18 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.response;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public record MovieResponse(
+        UUID id,
+        Integer year,
+        String title,
+        Set<StudioResponse> studios,
+        Set<MovieProducerResponse> producers,
+        Boolean winner) {
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/response/ProducerMovieResponse.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/response/ProducerMovieResponse.java
@@ -1,0 +1,13 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.response;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record ProducerMovieResponse(
+        UUID id,
+        Integer year,
+        String title,
+        Set<StudioResponse> studios,
+        Boolean winner) {
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/response/ProducerResponse.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/response/ProducerResponse.java
@@ -1,0 +1,12 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.response;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record ProducerResponse(
+        UUID id,
+        String name,
+        Set<ProducerMovieResponse> movies
+) {
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/response/StudioResponse.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/response/StudioResponse.java
@@ -1,0 +1,7 @@
+package com.texoit.goldenraspberryawardsapi.adapters.in.controller.response;
+
+import java.util.UUID;
+
+public record StudioResponse(UUID id, String name) {
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertMovieAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertMovieAdapter.java
@@ -21,7 +21,7 @@ public class InsertMovieAdapter implements InsertMovieOutputPort {
 
     @Override
     public Movie insert(Movie movie) {
-        MovieEntity movieEntity = movieRepository.save(movieEntityMapper.toMovieEntity(movie));
+        var movieEntity = movieRepository.save(movieEntityMapper.toMovieEntity(movie));
         return movieEntityMapper.toMovie(movieEntity);
     }
 

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertProducerAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertProducerAdapter.java
@@ -21,7 +21,7 @@ public class InsertProducerAdapter implements InsertProducerOutputPort {
 
     @Override
     public Producer insert(Producer producer) {
-        ProducerEntity producerEntity = producerRepository.save(producerEntityMapper.toProducerEntity(producer));
+        var producerEntity = producerRepository.save(producerEntityMapper.toProducerEntity(producer));
         return producerEntityMapper.toProducer(producerEntity);
     }
 

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertStudioAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/InsertStudioAdapter.java
@@ -21,7 +21,7 @@ public class InsertStudioAdapter implements InsertStudioOutputPort {
 
     @Override
     public Studio insert(Studio studio) {
-        StudioEntity studioEntity = studioRepository.save(studioEntityMapper.toStudioEntity(studio));
+        var studioEntity = studioRepository.save(studioEntityMapper.toStudioEntity(studio));
         return studioEntityMapper.toStudio(studioEntity);
     }
 

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/entity/MovieEntity.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/entity/MovieEntity.java
@@ -17,7 +17,7 @@ public class MovieEntity {
     private Integer year;
     private String title;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
             name = "movie_producer",
             joinColumns = @JoinColumn(name = "movie_id"),
@@ -25,7 +25,7 @@ public class MovieEntity {
     )
     private Set<ProducerEntity> producers;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
             name = "movie_studio",
             joinColumns = @JoinColumn(name = "movie_id"),

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/MovieEntityMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/MovieEntityMapper.java
@@ -10,22 +10,10 @@ import org.mapstruct.factory.Mappers;
 
 import java.util.stream.Collectors;
 
-@Mapper(componentModel = "spring", uses = {StudioEntityMapper.class, ProducerEntityMapper.class})
+@Mapper(componentModel = "spring", uses = {MovieStudioEntityMapper.class, MovieProducerEntityMapper.class})
 public interface MovieEntityMapper {
 
-    @Mapping(target = "producers", ignore = true)
     MovieEntity toMovieEntity(Movie movie);
-
-    ProducerEntityMapper producerEntityMapper = Mappers.getMapper(ProducerEntityMapper.class);
-
-    @AfterMapping
-    default void mapProducers(Movie movie, @MappingTarget MovieEntity movieEntity) {
-        movieEntity.setProducers(
-                movie.getProducers().stream()
-                        .map(producerEntityMapper::toProducerEntity)
-                        .collect(Collectors.toSet())
-        );
-    }
-
     Movie toMovie(MovieEntity movieEntity);
+
 }

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/MovieProducerEntityMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/MovieProducerEntityMapper.java
@@ -1,0 +1,25 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.ProducerRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.ProducerEntity;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import org.mapstruct.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Mapper(componentModel = "spring")
+public abstract class MovieProducerEntityMapper {
+
+    @Autowired
+    private ProducerRepository producerRepository;
+
+    @Mapping(target = "movies", ignore = true)
+    public abstract ProducerEntity toProducerEntity(Producer producer);
+    @Mapping(target = "movies", ignore = true)
+    public abstract Producer toProducer(ProducerEntity producerEntity);
+
+    @AfterMapping
+    public ProducerEntity afterMapping(Producer producer, @MappingTarget ProducerEntity producerEntity) {
+        return producerRepository.findById(producer.getId()).orElseThrow();
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/MovieStudioEntityMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/MovieStudioEntityMapper.java
@@ -1,0 +1,28 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.ProducerRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.StudioRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.ProducerEntity;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Mapper(componentModel = "spring")
+public abstract class MovieStudioEntityMapper {
+
+    @Autowired
+    private StudioRepository studioRepository;
+
+    public abstract StudioEntity toStudioEntity(Studio studio);
+    public abstract Studio toStudio(StudioEntity studioEntity);
+
+    @AfterMapping
+    public StudioEntity afterMapping(Studio studio, @MappingTarget StudioEntity studioEntity) {
+        return studioRepository.findById(studio.getId()).orElseThrow();
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/ProducerEntityMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/ProducerEntityMapper.java
@@ -5,7 +5,7 @@ import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.Produc
 import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {ProducerMovieEntityMapper.class})
 public interface ProducerEntityMapper {
 
     ProducerEntity toProducerEntity(Producer producer);

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/ProducerMovieEntityMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/mapper/ProducerMovieEntityMapper.java
@@ -1,0 +1,16 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.MovieEntity;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ProducerMovieEntityMapper {
+
+    @Mapping(target = "producers", ignore = true)
+    MovieEntity toMovieEntity(Movie movie);
+    @Mapping(target = "producers", ignore = true)
+    Movie toMovie(MovieEntity movieEntity);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/infrastructure/ErrorHandler.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/infrastructure/ErrorHandler.java
@@ -1,0 +1,43 @@
+package com.texoit.goldenraspberryawardsapi.infrastructure;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@RestControllerAdvice
+public class ErrorHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<EntityNotFoundException> handleNotFoundError() {
+        return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<List<ValidationErrorDetail>> handleBadRequestError(MethodArgumentNotValidException ex) {
+        var errors = ex.getFieldErrors();
+        return ResponseEntity.badRequest().body(errors.stream().map(ValidationErrorDetail::new).toList());
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<List<ValidationErrorDetail>> handleBadRequestError(MethodArgumentTypeMismatchException ex) {
+        var errors = new ArrayList<FieldError>();
+        errors.add(new FieldError(ex.getName(), Objects.requireNonNull(ex.getPropertyName()), ex.getMessage()));
+        return ResponseEntity.badRequest().body(errors.stream().map(ValidationErrorDetail::new).toList());
+    }
+
+    public record ValidationErrorDetail(String field, String message) {
+        public ValidationErrorDetail(FieldError error) {
+            this(error.getField(), error.getDefaultMessage());
+        }
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,10 @@ spring.datasource.url=jdbc:h2:mem:goldenraspberryawards
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
+
 spring.jpa.properties.hibernate.globally_quoted_identifiers=true
+
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+
+server.error.include-stacktrace=never


### PR DESCRIPTION
### Changes Made

- Updated various components within controllers, mappers, and request/response objects for Movie, Producer, and Studio entities.
- Introduced dedicated mapper classes (MovieMapper, ProducerMapper, StudioMapper) for handling request/response conversions in controllers.
- Created specific request and response objects for various controller endpoints to enhance clarity and maintainability.
- Refactored the structure of repository adapters (InsertMovieAdapter, InsertProducerAdapter, InsertStudioAdapter) for better organization and adherence to architectural principles.
- Added new entities and mappers within the repository package to support the refactored structure.
- Modified the ErrorHandler class in the infrastructure package.

### Context
This pull request addresses GRA-005, focusing on a comprehensive refactoring of controllers, mappers, request/response objects, and repository adapters across Movie, Producer, and Studio entities. The changes aim to enhance the overall structure, readability, and maintainability of the codebase.

Specifically, the introduction of dedicated mapper classes provides a cleaner and more modular approach to handling conversions between domain objects and request/response formats. The refactored repository adapters and additional entities/mappers contribute to a more organized and cohesive architecture.