### PR TITLE
feature/GRA-006: Implementing FindById Endpoints, Use Cases, Adapters, and Configurations

### DIFF
--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/MovieController.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/MovieController.java
@@ -5,10 +5,10 @@ import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.MovieR
 import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.MovieResponse;
 import com.texoit.goldenraspberryawardsapi.adapters.out.repository.MovieRepository;
 import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.MovieEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.FindMovieByIdInputPort;
 import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertMovieInputPort;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -19,15 +19,13 @@ import java.util.UUID;
 public class MovieController {
 
     private final InsertMovieInputPort insertMovieInputPort;
+    private final FindMovieByIdInputPort findMovieByIdInputPort;
     private final MovieMapper movieMapper;
-    private final MovieRepository movieRepository;
-    private final MovieEntityMapper movieEntityMapper;
 
-    public MovieController(InsertMovieInputPort insertMovieInputPort, MovieMapper movieMapper, MovieRepository movieRepository, MovieEntityMapper movieEntityMapper) {
+    public MovieController(InsertMovieInputPort insertMovieInputPort, MovieMapper movieMapper, FindMovieByIdInputPort findMovieByIdInputPort) {
         this.insertMovieInputPort = insertMovieInputPort;
         this.movieMapper = movieMapper;
-        this.movieRepository = movieRepository;
-        this.movieEntityMapper = movieEntityMapper;
+        this.findMovieByIdInputPort = findMovieByIdInputPort;
     }
 
     @PostMapping
@@ -40,7 +38,7 @@ public class MovieController {
 
     @GetMapping("/{id}")
     public ResponseEntity<MovieResponse> retrieve(@PathVariable UUID id) {
-        var movieResponse = movieMapper.toMovieResponse(movieEntityMapper.toMovie(movieRepository.getReferenceById(id)));
+        var movieResponse = movieMapper.toMovieResponse(findMovieByIdInputPort.find(id));
         return ResponseEntity.ok(movieResponse);
     }
 

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/ProducerController.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/ProducerController.java
@@ -3,8 +3,7 @@ package com.texoit.goldenraspberryawardsapi.adapters.in.controller;
 import com.texoit.goldenraspberryawardsapi.adapters.in.controller.mapper.ProducerMapper;
 import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.ProducerRequest;
 import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.ProducerResponse;
-import com.texoit.goldenraspberryawardsapi.adapters.out.repository.ProducerRepository;
-import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.ProducerEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.FindProducerByIdInputPort;
 import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertProducerInputPort;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -18,15 +17,13 @@ import java.util.UUID;
 public class ProducerController {
 
     private final InsertProducerInputPort insertProducerInputPort;
+    private final FindProducerByIdInputPort findProducerByIdInputPort;
     private final ProducerMapper producerMapper;
-    private final ProducerRepository producerRepository;
-    private final ProducerEntityMapper producerEntityMapper;
 
-    public ProducerController(InsertProducerInputPort insertProducerInputPort, ProducerMapper producerMapper, ProducerRepository producerRepository, ProducerEntityMapper producerEntityMapper) {
+    public ProducerController(InsertProducerInputPort insertProducerInputPort, FindProducerByIdInputPort findProducerByIdInputPort, ProducerMapper producerMapper) {
         this.insertProducerInputPort = insertProducerInputPort;
+        this.findProducerByIdInputPort = findProducerByIdInputPort;
         this.producerMapper = producerMapper;
-        this.producerRepository = producerRepository;
-        this.producerEntityMapper = producerEntityMapper;
     }
 
     @PostMapping
@@ -39,7 +36,7 @@ public class ProducerController {
 
     @GetMapping("/{id}")
     public ResponseEntity<ProducerResponse> retrieve(@PathVariable UUID id) {
-        var producerResponse = producerMapper.toProducerResponse(producerEntityMapper.toProducer(producerRepository.getReferenceById(id)));
+        var producerResponse = producerMapper.toProducerResponse(findProducerByIdInputPort.find(id));
         return ResponseEntity.ok(producerResponse);
     }
 

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/StudioController.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/StudioController.java
@@ -3,8 +3,7 @@ package com.texoit.goldenraspberryawardsapi.adapters.in.controller;
 import com.texoit.goldenraspberryawardsapi.adapters.in.controller.mapper.StudioMapper;
 import com.texoit.goldenraspberryawardsapi.adapters.in.controller.request.StudioRequest;
 import com.texoit.goldenraspberryawardsapi.adapters.in.controller.response.StudioResponse;
-import com.texoit.goldenraspberryawardsapi.adapters.out.repository.StudioRepository;
-import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.MovieStudioEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.FindStudioByIdInputPort;
 import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertStudioInputPort;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -18,15 +17,13 @@ import java.util.UUID;
 public class StudioController {
 
     private final InsertStudioInputPort insertStudioInputPort;
+    private final FindStudioByIdInputPort findStudioByIdInputPort;
     private final StudioMapper studioMapper;
-    private final MovieStudioEntityMapper studioEntityMapper;
-    private final StudioRepository studioRepository;
 
-    public StudioController(InsertStudioInputPort insertStudioInputPort, StudioMapper studioMapper, MovieStudioEntityMapper studioEntityMapper, StudioRepository studioRepository) {
+    public StudioController(InsertStudioInputPort insertStudioInputPort, FindStudioByIdInputPort findStudioByIdInputPort, StudioMapper studioMapper) {
         this.insertStudioInputPort = insertStudioInputPort;
+        this.findStudioByIdInputPort = findStudioByIdInputPort;
         this.studioMapper = studioMapper;
-        this.studioEntityMapper = studioEntityMapper;
-        this.studioRepository = studioRepository;
     }
 
     @PostMapping
@@ -39,7 +36,7 @@ public class StudioController {
 
     @GetMapping("/{id}")
     public ResponseEntity<StudioResponse> retrieve(@PathVariable UUID id) {
-        var studioResponse = studioMapper.toStudioResponse(studioEntityMapper.toStudio(studioRepository.getReferenceById(id)));
+        var studioResponse = studioMapper.toStudioResponse(findStudioByIdInputPort.find(id));
         return ResponseEntity.ok(studioResponse);
     }
 }

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/FindMovieByIdAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/FindMovieByIdAdapter.java
@@ -1,0 +1,27 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.MovieRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.MovieEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.FindMovieByIdOutputPort;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class FindMovieByIdAdapter implements FindMovieByIdOutputPort {
+
+    private final MovieRepository movieRepository;
+    private final MovieEntityMapper movieEntityMapper;
+
+    public FindMovieByIdAdapter(MovieRepository movieRepository, MovieEntityMapper movieEntityMapper) {
+        this.movieRepository = movieRepository;
+        this.movieEntityMapper = movieEntityMapper;
+    }
+
+    @Override
+    public Movie find(UUID id) {
+        var movieEntity = movieRepository.getReferenceById(id);
+        return movieEntityMapper.toMovie(movieEntity);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/FindProducerByIdAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/FindProducerByIdAdapter.java
@@ -1,0 +1,27 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.ProducerRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.ProducerEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.FindProducerByIdOutputPort;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class FindProducerByIdAdapter implements FindProducerByIdOutputPort {
+
+    private final ProducerRepository producerRepository;
+    private final ProducerEntityMapper producerEntityMapper;
+
+    public FindProducerByIdAdapter(ProducerRepository producerRepository, ProducerEntityMapper producerEntityMapper) {
+        this.producerRepository = producerRepository;
+        this.producerEntityMapper = producerEntityMapper;
+    }
+
+    @Override
+    public Producer find(UUID id) {
+        var producerEntity = producerRepository.getReferenceById(id);
+        return producerEntityMapper.toProducer(producerEntity);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/FindStudioByIdAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/FindStudioByIdAdapter.java
@@ -1,0 +1,28 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.StudioRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.StudioEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.FindStudioByIdOutputPort;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class FindStudioByIdAdapter implements FindStudioByIdOutputPort {
+
+    private final StudioRepository studioRepository;
+    private final StudioEntityMapper studioEntityMapper;
+
+    public FindStudioByIdAdapter(StudioRepository studioRepository, StudioEntityMapper studioEntityMapper) {
+        this.studioRepository = studioRepository;
+        this.studioEntityMapper = studioEntityMapper;
+    }
+
+    @Override
+    public Studio find(UUID id) {
+        var studioEntity = studioRepository.getReferenceById(id);
+        return studioEntityMapper.toStudio(studioEntity);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/FindMovieByIdUseCase.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/FindMovieByIdUseCase.java
@@ -1,0 +1,21 @@
+package com.texoit.goldenraspberryawardsapi.application.core.usecase;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.FindMovieByIdInputPort;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.FindMovieByIdOutputPort;
+
+import java.util.UUID;
+
+public class FindMovieByIdUseCase implements FindMovieByIdInputPort {
+
+    private final FindMovieByIdOutputPort findMovieByIdOutputPort;
+
+    public FindMovieByIdUseCase(FindMovieByIdOutputPort findMovieByIdOutputPort) {
+        this.findMovieByIdOutputPort = findMovieByIdOutputPort;
+    }
+
+    @Override
+    public Movie find(UUID id) {
+        return findMovieByIdOutputPort.find(id);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/FindProducerByIdUseCase.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/FindProducerByIdUseCase.java
@@ -1,0 +1,21 @@
+package com.texoit.goldenraspberryawardsapi.application.core.usecase;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.FindProducerByIdInputPort;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.FindProducerByIdOutputPort;
+
+import java.util.UUID;
+
+public class FindProducerByIdUseCase implements FindProducerByIdInputPort {
+
+    private final FindProducerByIdOutputPort findProducerByIdOutputPort;
+
+    public FindProducerByIdUseCase(FindProducerByIdOutputPort findProducerByIdOutputPort) {
+        this.findProducerByIdOutputPort = findProducerByIdOutputPort;
+    }
+
+    @Override
+    public Producer find(UUID id) {
+        return findProducerByIdOutputPort.find(id);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/FindStudioByIdUseCase.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/FindStudioByIdUseCase.java
@@ -1,0 +1,22 @@
+package com.texoit.goldenraspberryawardsapi.application.core.usecase;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.FindStudioByIdInputPort;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.FindStudioByIdOutputPort;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class FindStudioByIdUseCase implements FindStudioByIdInputPort {
+
+    private final FindStudioByIdOutputPort findStudioByIdOutputPort;
+
+    public FindStudioByIdUseCase(FindStudioByIdOutputPort findStudioByIdOutputPort) {
+        this.findStudioByIdOutputPort = findStudioByIdOutputPort;
+    }
+
+    @Override
+    public Studio find(UUID id) {
+        return findStudioByIdOutputPort.find(id);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/FindMovieByIdInputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/FindMovieByIdInputPort.java
@@ -1,0 +1,11 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.in;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+
+import java.util.UUID;
+
+public interface FindMovieByIdInputPort {
+
+    Movie find(UUID id);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/FindProducerByIdInputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/FindProducerByIdInputPort.java
@@ -1,0 +1,12 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.in;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+
+import java.util.UUID;
+
+public interface FindProducerByIdInputPort {
+
+    Producer find(UUID id);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/FindStudioByIdInputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/FindStudioByIdInputPort.java
@@ -1,0 +1,12 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.in;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FindStudioByIdInputPort {
+
+    Studio find(UUID id);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/FindMovieByIdOutputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/FindMovieByIdOutputPort.java
@@ -1,0 +1,11 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.out;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Movie;
+
+import java.util.UUID;
+
+public interface FindMovieByIdOutputPort {
+
+    Movie find(UUID id);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/FindProducerByIdOutputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/FindProducerByIdOutputPort.java
@@ -1,0 +1,12 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.out;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+
+import java.util.UUID;
+
+public interface FindProducerByIdOutputPort {
+
+    Producer find(UUID id);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/FindStudioByIdOutputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/FindStudioByIdOutputPort.java
@@ -1,0 +1,12 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.out;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FindStudioByIdOutputPort {
+
+    Studio find(UUID id);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/config/FindMovieByIdConfig.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/config/FindMovieByIdConfig.java
@@ -1,0 +1,16 @@
+package com.texoit.goldenraspberryawardsapi.config;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.FindMovieByIdAdapter;
+import com.texoit.goldenraspberryawardsapi.application.core.usecase.FindMovieByIdUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FindMovieByIdConfig {
+
+    @Bean
+    public FindMovieByIdUseCase findMovieByIdUseCase(FindMovieByIdAdapter findMovieByIdAdapter) {
+        return new FindMovieByIdUseCase(findMovieByIdAdapter);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/config/FindProducerByIdConfig.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/config/FindProducerByIdConfig.java
@@ -1,0 +1,16 @@
+package com.texoit.goldenraspberryawardsapi.config;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.FindProducerByIdAdapter;
+import com.texoit.goldenraspberryawardsapi.application.core.usecase.FindProducerByIdUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FindProducerByIdConfig {
+
+    @Bean
+    public FindProducerByIdUseCase findProducerByIdUseCase(FindProducerByIdAdapter findProducerByIdAdapter) {
+        return new FindProducerByIdUseCase(findProducerByIdAdapter);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/config/FindStudioByIdConfig.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/config/FindStudioByIdConfig.java
@@ -1,0 +1,16 @@
+package com.texoit.goldenraspberryawardsapi.config;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.FindStudioByIdAdapter;
+import com.texoit.goldenraspberryawardsapi.application.core.usecase.FindStudioByIdUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FindStudioByIdConfig {
+
+    @Bean
+    public FindStudioByIdUseCase findStudioByIdUseCase(FindStudioByIdAdapter findStudioByIdAdapter) {
+        return new FindStudioByIdUseCase(findStudioByIdAdapter);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/infrastructure/ErrorHandler.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/infrastructure/ErrorHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 @RestControllerAdvice
@@ -18,6 +19,11 @@ public class ErrorHandler {
 
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<EntityNotFoundException> handleNotFoundError() {
+        return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<NoSuchElementException> handleNoSuchElementError() {
         return ResponseEntity.notFound().build();
     }
 


### PR DESCRIPTION
### Changes Made

- Added FindById endpoints in controllers (MovieController, ProducerController, StudioController) for Movie, Producer, and Studio entities.
- Implemented FindById use cases (FindMovieByIdUseCase, FindProducerByIdUseCase, FindStudioByIdUseCase) to handle retrieval by ID.
- Created input and output ports (FindMovieByIdInputPort, FindProducerByIdInputPort, FindStudioByIdInputPort, FindMovieByIdOutputPort, FindProducerByIdOutputPort, FindStudioByIdOutputPort) for decoupling use cases from adapters.
- Introduced FindById adapters (FindMovieByIdAdapter, FindProducerByIdAdapter, FindStudioByIdAdapter) responsible for interacting with the database.
- Configured Spring Beans (FindMovieByIdConfig, FindProducerByIdConfig, FindStudioByIdConfig) for dependency injection of use cases.
- Updated ErrorHandler class in the infrastructure package to handle EntityNotFoundException for FindById operations.

### Context
This pull request addresses GRA-006, focusing on the introduction of FindById endpoints, use cases, adapters, and configurations across Movie, Producer, and Studio entities. The changes aim to provide a standardized way to retrieve entities by their IDs.

The implementation follows the principles of hexagonal architecture, ensuring separation of concerns and modularity. The newly introduced components enhance the API's functionality, enabling clients to retrieve specific entities based on their unique identifiers.