### PR TITLE
feature/GRA-007: Implementing FindByNameOrSave Use Case, Adapter, and Configuration for Studio and Producer

### DIFF
--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/FindProducerByNameAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/FindProducerByNameAdapter.java
@@ -1,0 +1,27 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.ProducerRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.ProducerEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.FindProducerByNameOutputPort;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class FindProducerByNameAdapter implements FindProducerByNameOutputPort {
+
+    private final ProducerRepository producerRepository;
+    private final ProducerEntityMapper producerEntityMapper;
+
+    public FindProducerByNameAdapter(ProducerRepository producerRepository, ProducerEntityMapper producerEntityMapper) {
+        this.producerRepository = producerRepository;
+        this.producerEntityMapper = producerEntityMapper;
+    }
+
+    @Override
+    public Optional<Producer> find(String name) {
+        var producerEntity = producerRepository.findByName(name);
+        return producerEntity.map(producerEntityMapper::toProducer);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/FindStudioByNameAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/FindStudioByNameAdapter.java
@@ -1,0 +1,28 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.StudioRepository;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.mapper.StudioEntityMapper;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.FindStudioByNameOutputPort;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class FindStudioByNameAdapter implements FindStudioByNameOutputPort {
+
+    private final StudioRepository studioRepository;
+    private final StudioEntityMapper studioEntityMapper;
+
+    public FindStudioByNameAdapter(StudioRepository studioRepository, StudioEntityMapper studioEntityMapper) {
+        this.studioRepository = studioRepository;
+        this.studioEntityMapper = studioEntityMapper;
+    }
+
+    @Override
+    public Optional<Studio> find(String name) {
+        var studioEntity = studioRepository.findByName(name);
+        return studioEntity.map(studioEntityMapper::toStudio);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/ProducerRepository.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/ProducerRepository.java
@@ -1,9 +1,14 @@
 package com.texoit.goldenraspberryawardsapi.adapters.out.repository;
 
 import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.ProducerEntity;
+import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ProducerRepository extends JpaRepository<ProducerEntity, UUID> {
+
+    Optional<ProducerEntity> findByName(String name);
+
 }

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/StudioRepository.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/StudioRepository.java
@@ -3,7 +3,11 @@ package com.texoit.goldenraspberryawardsapi.adapters.out.repository;
 import com.texoit.goldenraspberryawardsapi.adapters.out.repository.entity.StudioEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface StudioRepository extends JpaRepository<StudioEntity, UUID> {
+
+    Optional<StudioEntity> findByName(String name);
+
 }

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/entity/ProducerEntity.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/repository/entity/ProducerEntity.java
@@ -14,7 +14,7 @@ public class ProducerEntity {
     @Column(unique = true)
     private String name;
 
-    @ManyToMany(mappedBy = "producers")
+    @ManyToMany(mappedBy = "producers", fetch = FetchType.EAGER)
     private final Set<MovieEntity> movies;
 
     public ProducerEntity() {

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/FindProducerByNameOrSaveUseCase.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/FindProducerByNameOrSaveUseCase.java
@@ -1,0 +1,23 @@
+package com.texoit.goldenraspberryawardsapi.application.core.usecase;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.FindProducerByNameOrSaveInputPort;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertProducerInputPort;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.FindProducerByNameOutputPort;
+
+public class FindProducerByNameOrSaveUseCase implements FindProducerByNameOrSaveInputPort {
+
+    private final FindProducerByNameOutputPort findProducerByNameOutputPort;
+    private final InsertProducerInputPort insertProducerInputPort;
+
+    public FindProducerByNameOrSaveUseCase(FindProducerByNameOutputPort findProducerByNameOutputPort, InsertProducerInputPort insertProducerInputPort) {
+        this.findProducerByNameOutputPort = findProducerByNameOutputPort;
+        this.insertProducerInputPort = insertProducerInputPort;
+    }
+
+    @Override
+    public Producer execute(Producer producer) {
+        var search = findProducerByNameOutputPort.find(producer.getName());
+        return search.orElseGet(() -> insertProducerInputPort.insert(producer));
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/FindStudioByNameOrSaveUseCase.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/core/usecase/FindStudioByNameOrSaveUseCase.java
@@ -1,0 +1,25 @@
+package com.texoit.goldenraspberryawardsapi.application.core.usecase;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.FindStudioByNameOrSaveInputPort;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertStudioInputPort;
+import com.texoit.goldenraspberryawardsapi.application.ports.out.FindStudioByNameOutputPort;
+
+import java.util.Optional;
+
+public class FindStudioByNameOrSaveUseCase implements FindStudioByNameOrSaveInputPort {
+
+    private final FindStudioByNameOutputPort findStudioByNameOutputPort;
+    private final InsertStudioInputPort insertStudioInputPort;
+
+    public FindStudioByNameOrSaveUseCase(FindStudioByNameOutputPort findStudioByNameOutputPort, InsertStudioInputPort insertStudioInputPort) {
+        this.findStudioByNameOutputPort = findStudioByNameOutputPort;
+        this.insertStudioInputPort = insertStudioInputPort;
+    }
+
+    @Override
+    public Studio execute(Studio studio) {
+        var search = findStudioByNameOutputPort.find(studio.getName());
+        return search.orElseGet(() -> insertStudioInputPort.insert(studio));
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/FindProducerByNameOrSaveInputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/FindProducerByNameOrSaveInputPort.java
@@ -1,0 +1,10 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.in;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+
+public interface FindProducerByNameOrSaveInputPort {
+
+    Producer execute(Producer studio);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/FindStudioByNameOrSaveInputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/in/FindStudioByNameOrSaveInputPort.java
@@ -1,0 +1,9 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.in;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+
+public interface FindStudioByNameOrSaveInputPort {
+
+    Studio execute(Studio studio);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/FindProducerByNameOutputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/FindProducerByNameOutputPort.java
@@ -1,0 +1,12 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.out;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Producer;
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+
+import java.util.Optional;
+
+public interface FindProducerByNameOutputPort {
+
+    Optional<Producer> find(String name);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/FindStudioByNameOutputPort.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/application/ports/out/FindStudioByNameOutputPort.java
@@ -1,0 +1,11 @@
+package com.texoit.goldenraspberryawardsapi.application.ports.out;
+
+import com.texoit.goldenraspberryawardsapi.application.core.domain.Studio;
+
+import java.util.Optional;
+
+public interface FindStudioByNameOutputPort {
+
+    Optional<Studio> find(String name);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/config/FindProducerByNameOrSaveConfig.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/config/FindProducerByNameOrSaveConfig.java
@@ -1,0 +1,18 @@
+package com.texoit.goldenraspberryawardsapi.config;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.FindProducerByNameAdapter;
+import com.texoit.goldenraspberryawardsapi.application.core.usecase.FindProducerByNameOrSaveUseCase;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertProducerInputPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FindProducerByNameOrSaveConfig {
+
+    @Bean
+    public FindProducerByNameOrSaveUseCase findProducerByNameOrSaveUseCase(FindProducerByNameAdapter findProducerByNameAdapter, InsertProducerInputPort insertProducerInputPort
+    ) {
+        return new FindProducerByNameOrSaveUseCase(findProducerByNameAdapter, insertProducerInputPort);
+    }
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/config/FindStudioByNameOrSaveConfig.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/config/FindStudioByNameOrSaveConfig.java
@@ -1,0 +1,21 @@
+package com.texoit.goldenraspberryawardsapi.config;
+
+import com.texoit.goldenraspberryawardsapi.adapters.out.FindStudioByIdAdapter;
+import com.texoit.goldenraspberryawardsapi.adapters.out.FindStudioByNameAdapter;
+import com.texoit.goldenraspberryawardsapi.adapters.out.InsertStudioAdapter;
+import com.texoit.goldenraspberryawardsapi.application.core.usecase.FindStudioByIdUseCase;
+import com.texoit.goldenraspberryawardsapi.application.core.usecase.FindStudioByNameOrSaveUseCase;
+import com.texoit.goldenraspberryawardsapi.application.ports.in.InsertStudioInputPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FindStudioByNameOrSaveConfig {
+
+    @Bean
+    public FindStudioByNameOrSaveUseCase findStudioByNameOrSaveUseCase(FindStudioByNameAdapter findStudioByNameAdapter, InsertStudioInputPort insertStudioInputPort
+    ) {
+        return new FindStudioByNameOrSaveUseCase(findStudioByNameAdapter, insertStudioInputPort);
+    }
+
+}


### PR DESCRIPTION
### Changes Made

- Introduced FindProducerByNameAdapter and FindStudioByNameAdapter to facilitate finding entities by name.
- Implemented FindProducerByNameOrSaveUseCase and FindStudioByNameOrSaveUseCase to handle the logic of finding entities by name or saving them if not found.
- Created input and output ports (FindProducerByNameOrSaveInputPort, FindStudioByNameOrSaveInputPort, - FindProducerByNameOutputPort, FindStudioByNameOutputPort) for decoupling use cases from adapters.
- Updated ProducerEntity to include a EAGER fetch type.
- Modified ProducerRepository and StudioRepository to include methods for finding entities by name.
- Configured Spring Beans (FindProducerByNameOrSaveConfig, FindStudioByNameOrSaveConfig) for dependency injection of use cases.

### Context

This pull request addresses GRA-007, focusing on the implementation of FindByName or Save functionality for Producer and Studio entities. The changes aim to provide a mechanism to locate entities by name or create them if not found.

The use cases follow a modular and decoupled design, enhancing maintainability and promoting adherence to hexagonal architecture principles. The configuration and adapters enable seamless integration of this new functionality into the Golden Raspberry Awards API.