### PR TITLE
feature/GRA-014 - Implement Refreshable Repositories and Enable RefreshableJpaRepository

### DIFF
--- a/src/main/java/com/texoit/goldenraspberryawardsapi/GoldenRaspberryAwardsApiApplication.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/GoldenRaspberryAwardsApiApplication.java
@@ -1,11 +1,14 @@
 package com.texoit.goldenraspberryawardsapi;
 
+import com.texoit.goldenraspberryawardsapi.adapters.out.base.repository.RefreshableJpaRepositoryImpl;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableCaching
+@EnableJpaRepositories(repositoryBaseClass = RefreshableJpaRepositoryImpl.class)
 public class GoldenRaspberryAwardsApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/base/repository/RefreshableJpaRepository.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/base/repository/RefreshableJpaRepository.java
@@ -1,0 +1,12 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.base.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+import java.io.Serializable;
+
+@NoRepositoryBean
+public interface RefreshableJpaRepository<T, ID extends Serializable> extends JpaRepository<T, ID> {
+    void refresh(T t);
+
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/base/repository/RefreshableJpaRepositoryImpl.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/base/repository/RefreshableJpaRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.texoit.goldenraspberryawardsapi.adapters.out.base.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.Serializable;
+
+public class RefreshableJpaRepositoryImpl<T, ID extends Serializable> extends SimpleJpaRepository<T, ID> implements RefreshableJpaRepository<T, ID> {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+
+    public RefreshableJpaRepositoryImpl(JpaEntityInformation entityInformation, EntityManager entityManager) {
+        super(entityInformation, entityManager);
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    @Transactional
+    public void refresh(T t) {
+        entityManager.refresh(t);
+    }
+}

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/movie/InsertMovieAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/movie/InsertMovieAdapter.java
@@ -5,6 +5,7 @@ import com.texoit.goldenraspberryawardsapi.adapters.out.movie.repository.mapper.
 import com.texoit.goldenraspberryawardsapi.application.core.domain.movie.Movie;
 import com.texoit.goldenraspberryawardsapi.application.ports.out.movie.InsertMovieOutputPort;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class InsertMovieAdapter implements InsertMovieOutputPort {
@@ -19,8 +20,10 @@ public class InsertMovieAdapter implements InsertMovieOutputPort {
     }
 
     @Override
+    @Transactional
     public Movie insert(Movie movie) {
-        var movieEntity = movieRepository.save(movieEntityMapper.toMovieEntity(movie));
+        var movieEntity = movieRepository.saveAndFlush(movieEntityMapper.toMovieEntity(movie));
+        movieRepository.refresh(movieEntity);
         return movieEntityMapper.toMovie(movieEntity);
     }
 

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/movie/repository/MovieRepository.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/movie/repository/MovieRepository.java
@@ -1,12 +1,12 @@
 package com.texoit.goldenraspberryawardsapi.adapters.out.movie.repository;
 
+import com.texoit.goldenraspberryawardsapi.adapters.out.base.repository.RefreshableJpaRepository;
 import com.texoit.goldenraspberryawardsapi.adapters.out.movie.repository.entity.MovieEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 import java.util.UUID;
 
-public interface MovieRepository extends JpaRepository<MovieEntity, UUID> {
+public interface MovieRepository extends RefreshableJpaRepository<MovieEntity, UUID> {
 
     Optional<MovieEntity> findByTitle(String title);
 

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/movie/repository/mapper/MovieProducerEntityMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/movie/repository/mapper/MovieProducerEntityMapper.java
@@ -1,28 +1,16 @@
 package com.texoit.goldenraspberryawardsapi.adapters.out.movie.repository.mapper;
 
-import com.texoit.goldenraspberryawardsapi.adapters.out.producer.repository.ProducerRepository;
 import com.texoit.goldenraspberryawardsapi.adapters.out.producer.repository.entity.ProducerEntity;
 import com.texoit.goldenraspberryawardsapi.application.core.domain.producer.Producer;
-import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Mapper(componentModel = "spring")
-public abstract class MovieProducerEntityMapper {
-
-    @Autowired
-    private ProducerRepository producerRepository;
+public interface MovieProducerEntityMapper {
 
     @Mapping(target = "movies", ignore = true)
-    public abstract ProducerEntity toProducerEntity(Producer producer);
+    ProducerEntity toProducerEntity(Producer producer);
     @Mapping(target = "movies", ignore = true)
-    public abstract Producer toProducer(ProducerEntity producerEntity);
-
-    @AfterMapping
-    public ProducerEntity afterMapping(Producer producer, @MappingTarget ProducerEntity producerEntity) {
-        return producerRepository.findById(producer.getId()).orElseThrow();
-    }
+    Producer toProducer(ProducerEntity producerEntity);
 
 }

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/movie/repository/mapper/MovieStudioEntityMapper.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/movie/repository/mapper/MovieStudioEntityMapper.java
@@ -1,25 +1,13 @@
 package com.texoit.goldenraspberryawardsapi.adapters.out.movie.repository.mapper;
 
-import com.texoit.goldenraspberryawardsapi.adapters.out.studio.repository.StudioRepository;
 import com.texoit.goldenraspberryawardsapi.adapters.out.studio.repository.entity.StudioEntity;
 import com.texoit.goldenraspberryawardsapi.application.core.domain.studio.Studio;
-import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
-import org.mapstruct.MappingTarget;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Mapper(componentModel = "spring")
-public abstract class MovieStudioEntityMapper {
+public interface MovieStudioEntityMapper {
 
-    @Autowired
-    private StudioRepository studioRepository;
-
-    public abstract StudioEntity toStudioEntity(Studio studio);
-    public abstract Studio toStudio(StudioEntity studioEntity);
-
-    @AfterMapping
-    public StudioEntity afterMapping(Studio studio, @MappingTarget StudioEntity studioEntity) {
-        return studioRepository.findById(studio.getId()).orElseThrow();
-    }
+    StudioEntity toStudioEntity(Studio studio);
+    Studio toStudio(StudioEntity studioEntity);
 
 }

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/producer/InsertProducerAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/producer/InsertProducerAdapter.java
@@ -5,6 +5,7 @@ import com.texoit.goldenraspberryawardsapi.adapters.out.producer.repository.mapp
 import com.texoit.goldenraspberryawardsapi.application.core.domain.producer.Producer;
 import com.texoit.goldenraspberryawardsapi.application.ports.out.producer.InsertProducerOutputPort;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class InsertProducerAdapter implements InsertProducerOutputPort {
@@ -19,8 +20,10 @@ public class InsertProducerAdapter implements InsertProducerOutputPort {
     }
 
     @Override
+    @Transactional
     public Producer insert(Producer producer) {
-        var producerEntity = producerRepository.save(producerEntityMapper.toProducerEntity(producer));
+        var producerEntity = producerRepository.saveAndFlush(producerEntityMapper.toProducerEntity(producer));
+        producerRepository.refresh(producerEntity);
         return producerEntityMapper.toProducer(producerEntity);
     }
 

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/producer/repository/ProducerRepository.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/producer/repository/ProducerRepository.java
@@ -1,16 +1,16 @@
 package com.texoit.goldenraspberryawardsapi.adapters.out.producer.repository;
 
+import com.texoit.goldenraspberryawardsapi.adapters.out.base.repository.RefreshableJpaRepository;
 import com.texoit.goldenraspberryawardsapi.adapters.out.producer.repository.entity.ProducerEntity;
 import com.texoit.goldenraspberryawardsapi.adapters.out.producer.repository.response.ProducerIntervalsProjection;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface ProducerRepository extends JpaRepository<ProducerEntity, UUID> {
+public interface ProducerRepository extends RefreshableJpaRepository<ProducerEntity, UUID> {
 
     @Cacheable(value="producers", unless = "#result == null")
     Optional<ProducerEntity> findByName(String name);

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/studio/InsertStudioAdapter.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/studio/InsertStudioAdapter.java
@@ -5,6 +5,7 @@ import com.texoit.goldenraspberryawardsapi.adapters.out.studio.repository.mapper
 import com.texoit.goldenraspberryawardsapi.application.core.domain.studio.Studio;
 import com.texoit.goldenraspberryawardsapi.application.ports.out.studio.InsertStudioOutputPort;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class InsertStudioAdapter implements InsertStudioOutputPort {
@@ -19,8 +20,10 @@ public class InsertStudioAdapter implements InsertStudioOutputPort {
     }
 
     @Override
+    @Transactional
     public Studio insert(Studio studio) {
-        var studioEntity = studioRepository.save(studioEntityMapper.toStudioEntity(studio));
+        var studioEntity = studioRepository.saveAndFlush(studioEntityMapper.toStudioEntity(studio));
+        studioRepository.refresh(studioEntity);
         return studioEntityMapper.toStudio(studioEntity);
     }
 

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/studio/repository/StudioRepository.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/adapters/out/studio/repository/StudioRepository.java
@@ -1,13 +1,13 @@
 package com.texoit.goldenraspberryawardsapi.adapters.out.studio.repository;
 
+import com.texoit.goldenraspberryawardsapi.adapters.out.base.repository.RefreshableJpaRepository;
 import com.texoit.goldenraspberryawardsapi.adapters.out.studio.repository.entity.StudioEntity;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 import java.util.UUID;
 
-public interface StudioRepository extends JpaRepository<StudioEntity, UUID> {
+public interface StudioRepository extends RefreshableJpaRepository<StudioEntity, UUID> {
 
     @Cacheable(value="studios", unless = "#result == null")
     Optional<StudioEntity> findByName(String name);


### PR DESCRIPTION
### Changes Made

- Implemented refresh repositories for JPA data to mitigate bug [DATAREST-1445].
- Introduced refreshable repositories for Studio, Producer, and Movie entities and their associated adapters.
- Enabled RefreshableJpaRepository for JPA repositories.

### Context

These changes address various aspects of the application to enhance its functionality and reliability. By implementing refresh repositories for JPA data, the bug [DATAREST-1445] is mitigated, ensuring smoother operation. Additionally, the introduction of refreshable repositories for Studio, Producer, and Movie entities improves data management and integrity. The associated adapters ensure efficient data insertion, contributing to a more robust application architecture. Finally, enabling RefreshableJpaRepository for JPA repositories enhances refreshability and reliability, further solidifying the data management system.

This pull request encompasses these changes to enhance the overall performance and stability of the application.