### PR TITLE
feature/GRA-017 - Custom Error Messages and OpenAPI Integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.4.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/texoit/goldenraspberryawardsapi/infrastructure/ErrorHandler.java
+++ b/src/main/java/com/texoit/goldenraspberryawardsapi/infrastructure/ErrorHandler.java
@@ -49,7 +49,13 @@ public class ErrorHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<ModelMap> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
         var errorsMap = new ModelMap();
-        errorsMap.addAttribute("errors", Map.of("message", "Falha na integridade dos dados"));
+
+        String customMessage = String.format(
+                "Falha na integridade dos dados.%s",
+                ex.getMessage().contains("Unique index or primary key violation") ? " Já existe um registro com os mesmos dados fornecidos." : ""
+        );
+
+        errorsMap.addAttribute("errors", Map.of("message", customMessage));
         return ResponseEntity.badRequest().body(errorsMap);
     }
 

--- a/src/test/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/producer/ProducerControllerTest.java
+++ b/src/test/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/producer/ProducerControllerTest.java
@@ -111,7 +111,7 @@ public class ProducerControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(producerRequestToSave)))
                 .andExpect(status().isBadRequest()) // Then
-                .andExpect(jsonPath("$.errors.message").value("Falha na integridade dos dados")); // Then
+                .andExpect(jsonPath("$.errors.message").value("Falha na integridade dos dados. Já existe um registro com os mesmos dados fornecidos.")); // Then
     }
 
     @Test

--- a/src/test/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/studio/StudioControllerTest.java
+++ b/src/test/java/com/texoit/goldenraspberryawardsapi/adapters/in/controller/studio/StudioControllerTest.java
@@ -111,7 +111,7 @@ public class StudioControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(studioRequestToSave)))
                 .andExpect(status().isBadRequest()) // Then
-                .andExpect(jsonPath("$.errors.message").value("Falha na integridade dos dados")); // Then
+                .andExpect(jsonPath("$.errors.message").value("Falha na integridade dos dados. Já existe um registro com os mesmos dados fornecidos.")); // Then
     }
 
     @Test


### PR DESCRIPTION
### Changes Made

- Refactored the ErrorHandler class to dynamically generate custom error messages based on the type of exception encountered. Previously, a generic error message was returned for all exceptions, hindering the clarity of error reporting. Now, when an exception occurs, the error message is tailored to include specific context, such as indicating a duplicate entry if the exception message contains "Unique index or primary key violation". This enhancement improves the usability and effectiveness of error reporting in the application.
- Added the Springdoc OpenAPI dependency to the pom.xml file to facilitate the generation of OpenAPI documentation for the Spring-based RESTful APIs. This integration enhances the API documentation capabilities, providing automated and interactive documentation that simplifies API understanding, testing, and collaboration.

### Context
These changes aim to enhance the overall user experience and developer productivity by improving error reporting and API documentation capabilities. The custom error messages provide users with more actionable information when errors occur during data processing, leading to faster issue resolution. Additionally, integrating Springdoc OpenAPI streamlines API documentation workflows, making it easier for developers to understand, test, and collaborate on APIs. This pull request consolidates these enhancements, contributing to a more robust and user-friendly application.